### PR TITLE
minor modification for kernel compatibility with CLIc

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/kernels/block_enumerate_x.cl
+++ b/src/main/java/net/haesleinhuepf/clij/kernels/block_enumerate_x.cl
@@ -1,17 +1,17 @@
-
+__const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
 __kernel void block_enumerate(
     IMAGE_dst_TYPE dst,
     IMAGE_src_TYPE src,
     IMAGE_src_sums_TYPE src_sums,
     int blocksize
-) {
-  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
-
+) 
+{
   const int x = get_global_id(0);
   const int z = get_global_id(1);
   const int y = get_global_id(2);
   float sum = 0;
+  
   for(int sx = 0; sx < x - 1; sx++)
   {
     sum = sum + READ_src_sums_IMAGE(src_sums,sampler,POS_src_sums_INSTANCE(sx,y,z,0)).x;

--- a/src/main/java/net/haesleinhuepf/clij/kernels/flag_existing_labels_x.cl
+++ b/src/main/java/net/haesleinhuepf/clij/kernels/flag_existing_labels_x.cl
@@ -1,7 +1,7 @@
 
 const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
-__kernel void flag_existing_intensities
+__kernel void flag_existing_labels
 (
   IMAGE_dst_TYPE dst,
   IMAGE_src_TYPE src

--- a/src/main/java/net/haesleinhuepf/clij/kernels/replace_intensities_x.cl
+++ b/src/main/java/net/haesleinhuepf/clij/kernels/replace_intensities_x.cl
@@ -3,7 +3,8 @@ const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDG
 
 __kernel void replace_intensities
 (
-  IMAGE_dst_TYPE dst, IMAGE_src_TYPE src,
+  IMAGE_dst_TYPE dst, 
+  IMAGE_src_TYPE src,
   IMAGE_map_TYPE map
 )
 {

--- a/src/main/java/net/haesleinhuepf/clij/kernels/sum_reduction_x.cl
+++ b/src/main/java/net/haesleinhuepf/clij/kernels/sum_reduction_x.cl
@@ -1,12 +1,12 @@
 
+__const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
 __kernel void sum_reduction_x(
     IMAGE_dst_TYPE dst,
     IMAGE_src_TYPE src,
     int blocksize
-) {
-  const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
-
+) 
+{
   const int x = get_global_id(0);
   const int z = get_global_id(1);
   const int y = get_global_id(2);


### PR DESCRIPTION
implementation of ConnectedComponentsLabellingBox:
- rename of block_enumerate.cl -> block_enumerate_x.cl. Required for CLIc. 
- set sampler outside of kernel like in all others (stylish modification, no impact)  

kernel renaming may break pyclesperanto and other cle implementation. Sorry!