### PR TITLE
Fix laplace box

### DIFF
--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -29,9 +29,9 @@ __kernel void laplace_box(
   }
 
   float result = 0;
-  for (int dx = -r.x; dx <= r.x; ++dx) {
-    for (int dy = -r.y; dy <= r.y; ++dy) {
-      for (int dz = -r.z; dz <= r.z; ++dz) {
+  for (int dx = -1; dx <= 1; ++dx) {
+    for (int dy = -1; dy <= 1; ++dy) {
+      for (int dz = -1; dz <= 1; ++dz) {
         if (dx == 0 && dy == 0 && dz == 0) {
           result += (float) READ_IMAGE(src, sampler, pos).x * norm;
         } else {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -21,9 +21,9 @@ __kernel void laplace_box(
   float norm = norm_table[sum - 1];
 
   float result = 0;
-  for (int dx = -1; dx <= 1; ++dx) {
-    for (int dy = -1; dy <= 1; ++dy) {
-      for (int dz = -1; dz <= 1; ++dz) {
+  for (int dx = -r.x; dx <= r.x; ++dx) {
+    for (int dy = -r.y; dy <= r.y; ++dy) {
+      for (int dz = -r.z; dz <= r.z; ++dz) {
         if (dx == 0 && dy == 0 && dz == 0) {
           result += (float) READ_IMAGE(src, sampler, pos).x * norm;
         } else {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -14,9 +14,9 @@ __kernel void laplace_box(
   if (GET_IMAGE_HEIGHT(src) > 1) { r.y = 1; }
   if (GET_IMAGE_WIDTH(src)  > 1) { r.x = 1; }
 
-  const float norm = 0;
-
+  float norm = 0;
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
+
   if ((r.x + r.y + r.z) > 2)
   {
     norm = 26;

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -16,7 +16,7 @@ __kernel void laplace_box(
 
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
   
-  const int norm = pow((int)(3), (int)(r.x + r.y + r.z)) - 1;
+  float norm = pow(3.0f, (int)(r.x + r.y + r.z)) - 1;
 
   float result = 0;
   for (int dx = -r.x; dx <= r.x; ++dx) {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -16,7 +16,7 @@ __kernel void laplace_box(
 
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
   
-  const int norm = pow(3, r.x + r.y + r.z) - 1;
+  const int norm = pow((int)(3), (int)(r.x + r.y + r.z)) - 1;
 
   float result = 0;
   for (int dx = -r.x; dx <= r.x; ++dx) {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -16,8 +16,8 @@ __kernel void laplace_box(
 
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
   
-  float norm = pow(3, r.x + r.y + r.z) - 1;
-
+  float norm = pow(3.0f, (int)(r.x + r.y + r.z)) - 1;
+  
   float result = 0;
   for (int dx = -r.x; dx <= r.x; ++dx) {
     for (int dy = -r.y; dy <= r.y; ++dy) {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -14,8 +14,19 @@ __kernel void laplace_box(
   if (GET_IMAGE_HEIGHT(src) > 1) { r.y = 1; }
   if (GET_IMAGE_WIDTH(src)  > 1) { r.x = 1; }
 
+  const float norm = 0;
+
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
-  const float norm = (r.z + r.y + r.z) * 2;
+  if ((r.x + r.y + r.z) > 2)
+  {
+    norm = 26;
+  } else if ((r.x + r.y + r.z) > 1)
+  {
+    norm = 8;
+  } else
+  {
+    norm = 2;
+  }
 
   float result = 0;
   for (int dx = -r.x; dx <= r.x; ++dx) {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -16,8 +16,8 @@ __kernel void laplace_box(
 
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
   
-  float norm = pow(3.0f, (int)(r.x + r.y + r.z)) - 1;
-  
+  const int norm = pow(3, r.x + r.y + r.z) - 1;
+
   float result = 0;
   for (int dx = -r.x; dx <= r.x; ++dx) {
     for (int dy = -r.y; dy <= r.y; ++dy) {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -14,19 +14,11 @@ __kernel void laplace_box(
   if (GET_IMAGE_HEIGHT(src) > 1) { r.y = 1; }
   if (GET_IMAGE_WIDTH(src)  > 1) { r.x = 1; }
 
-  float norm = 0;
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
-
-  if ((r.x + r.y + r.z) > 2)
-  {
-    norm = 26;
-  } else if ((r.x + r.y + r.z) > 1)
-  {
-    norm = 8;
-  } else
-  {
-    norm = 2;
-  }
+  
+  int sum = r.x + r.y + r.z;
+  const float norm_table[] = {2, 8, 26};
+  float norm = norm_table[sum - 1];
 
   float result = 0;
   for (int dx = -1; dx <= 1; ++dx) {

--- a/kernels/laplace_box.cl
+++ b/kernels/laplace_box.cl
@@ -16,9 +16,7 @@ __kernel void laplace_box(
 
   const POS_src_TYPE pos = POS_src_INSTANCE(x,y,z,0);
   
-  int sum = r.x + r.y + r.z;
-  const float norm_table[] = {2, 8, 26};
-  float norm = norm_table[sum - 1];
+  float norm = pow(3, r.x + r.y + r.z) - 1;
 
   float result = 0;
   for (int dx = -r.x; dx <= r.x; ++dx) {


### PR DESCRIPTION
I corrected the Laplacian box filter. It now calculates the output according to the norm which depends on the input (1D, 2D or 3D). 

The original version: 
https://github.com/clEsperanto/clij-opencl-kernels/blob/bdf7d0a3f4d64ef9b3a9e784be6bc3f1db6adf6e/kernels/laplace_box.cl#L18

The corrected version:
      `int sum = r.x + r.y + r.z;`
      `const float norm_table[] = {2, 8, 26};`
      `float norm = norm_table[sum - 1];`

With some other small changes in the loops.